### PR TITLE
Fix URL for confirmation email

### DIFF
--- a/CManagement/course_manager/views/View_Participants.py
+++ b/CManagement/course_manager/views/View_Participants.py
@@ -268,7 +268,7 @@ def process_enrollment(request, appointment_id):
     new_account.save()
     # TODO: replace hardcoded confirmation link below
     confirmation_link = (
-        "https://www.ifsr.de/kurse/kurse/confirm/"
+        "https://www.ifsr.de/kurse/confirm/"
         "{passwd}/{username}/{app_id}".format(
             passwd=pseudo_password,
             username=new_account.username,


### PR DESCRIPTION
Still just as hardcoded as before, but this should at least make it work for now.

See #20
